### PR TITLE
disable feed slider on community and collection home pages

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1330,7 +1330,7 @@ plugin.named.org.dspace.content.license.LicenseArgumentFormatter = \
 
 # enable syndication feeds - links display on community and collection home pages
 # (This setting is not used by XMLUI, as you enable feeds in your theme)
-webui.feed.enable = true
+webui.feed.enable = false
 # number of DSpace items per feed (the most recent submissions)
 webui.feed.items = 4
 # maximum number of feeds in memory cache


### PR DESCRIPTION
disable feed slider on community and collection home pages
